### PR TITLE
log outdated values rather than emitting them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 install:
   pip install -r requirements.txt ; pip install flake8
-before_script: 
-  flake8 src/signalfx_metadata.py
+before_script:
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 src/signalfx_metadata.py; fi
 script: 
   for x in src/*.py; do python $x once; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-0.0.27 / 2016-09-21
+0.0.28 / 2016-10-18
 ===================
+
+* Upgrade to latest signalfx-python v1.0.7
+* Log outdated metrics instead of emitting them
+
+0.0.27 / 2016-09-21
 
 * Periodically check if the plugin is running on AWS
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 psutil>=3.2.2
-signalfx>=1.0.4
+signalfx>=1.0.7
 simplejson>=3.8.1

--- a/run-tests/Dockerfile
+++ b/run-tests/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+
+WORKDIR /home
+RUN apt-get update -y \
+    && apt-get install -y python-dev wget gcc python-pip python-flake8

--- a/run-tests/cmdseq.sh
+++ b/run-tests/cmdseq.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+pip install nose
+pip install -r /plugin/requirements.txt
+cd /plugin
+echo "
+Running tests...
+"
+for x in src/*.py; do python $x once; done
+
+echo "
+Running flake8...
+"
+python -m flake8 src/collectd_dogstatsd.py src/dummy_collectd.py src/test_dogstatsd.py src/signalfx_metadata.py

--- a/run-tests/run-tests.sh
+++ b/run-tests/run-tests.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+
+tempfolder=$(mktemp -d ${SCRIPT_DIR}/0.XXXXXX)
+trap "rm -rf $tempfolder; docker stop signalfx-collectd-plugin-test; docker rm signalfx-collectd-plugin-test;" EXIT
+
+# Copy the rest of the repo into tempfolder
+cp $SCRIPT_DIR/../* $tempfolder
+cp -r $SCRIPT_DIR/../src $tempfolder
+
+# Copy the dockerfile to the tempfolder
+cp $SCRIPT_DIR/Dockerfile $tempfolder
+
+docker build -t signalfx-collectd-plugin-test $tempfolder
+
+docker run --name signalfx-collectd-plugin-test -ti \
+    -v $SCRIPT_DIR/../:/plugin signalfx-collectd-plugin-test /plugin/run-tests/cmdseq.sh

--- a/src/test_metadata.py
+++ b/src/test_metadata.py
@@ -33,61 +33,68 @@ class TestUtilizationFactory(object):
         self.utilization_factory = None
 
     def _gen(self, type_instances, plugin, type, plugin_instances=[""],
-             missing=0, values=1):
+             missing=0, values=1, increment_time=True):
         self.val += 1
         metrics = []
-        self.time += 10.0
+        if increment_time is True:
+            self.time += 10.0
         for type_instance in type_instances[:len(type_instances) - missing]:
             for plugin_instance in plugin_instances:
                 v = []
                 for i in range(values):
                     v.append(self.val)
-                metrics.append(dummy_collectd.Values(plugin=plugin,
-                                                     plugin_instance=plugin_instance,
-                                                     time=self.time, type=type,
-                                                     type_instance=type_instance,
-                                                     interval=10,
-                                                     values=v))
+                metrics.append(dummy_collectd.
+                               Values(plugin=plugin,
+                                      plugin_instance=plugin_instance,
+                                      time=self.time, type=type,
+                                      type_instance=type_instance,
+                                      interval=10,
+                                      values=v))
         return metrics
 
-    def gen_memory(self, missing=0):
+    def gen_memory(self, missing=0, increment_time=True):
         for m in self._gen(
                 ['used', 'cached', 'buffered', 'slab_recl', 'slab_unrecl',
                  'free'],
-                "memory", "memory", missing=missing):
+                "memory", "memory", missing=missing,
+                increment_time=increment_time):
             self.utilization_factory.write(m)
         self.utilization_factory.read()
 
-    def gen_cpu(self, missing=0):
+    def gen_cpu(self, missing=0, increment_time=True):
         for m in self._gen(
-                ['idle', 'steal', 'wait', 'system', 'user', 'nice', 'interrupt',
-                 'softirq'],
+                ['idle', 'steal', 'wait', 'system', 'user', 'nice',
+                 'interrupt', 'softirq'],
                 "aggregation", "cpu", plugin_instances=["cpu-average"],
-                missing=missing):
+                missing=missing, increment_time=increment_time):
+            print m
             self.utilization_factory.write(m)
         self.utilization_factory.read()
 
     def gen_df(self, missing=0, missing_plugin_instances=0,
-               additional_plugin_instances=[]):
+               additional_plugin_instances=[], increment_time=True):
         for m in self._gen(['reserved', 'free', 'used'],
                            "df", "df_complex", missing=missing,
                            plugin_instances=(["opt", "bin", "blarg"][:3 -
-                               missing_plugin_instances] +
-                                                 additional_plugin_instances)):
+                                             missing_plugin_instances] +
+                                             additional_plugin_instances),
+                           increment_time=increment_time):
             self.utilization_factory.write(m)
         self.utilization_factory.read()
 
-    def gen_disk(self, missing=0):
+    def gen_disk(self, missing=0, increment_time=True):
         for m in self._gen([''], "disk", "disk_ops",
                            plugin_instances=["sda", "hda", "sdb"][
-                                            :3 - missing], values=2):
+                                            :3 - missing], values=2,
+                           increment_time=increment_time):
             self.utilization_factory.write(m)
         self.utilization_factory.read()
 
-    def gen_network(self, missing=0):
+    def gen_network(self, missing=0, increment_time=True):
         for m in self._gen([''], "disk", "disk_ops",
                            plugin_instances=["eth0", "eth1", "lo"][
-                                            :3 - missing], values=2):
+                                            :3 - missing], values=2,
+                           increment_time=increment_time):
             self.utilization_factory.write(m)
         self.utilization_factory.read()
 
@@ -100,6 +107,10 @@ class TestUtilizationFactory(object):
         assert_equals(len(self.collectd_engine.dispatched_values), 1)
         self.utilization_factory.read()
         assert_equals(len(self.collectd_engine.dispatched_values), 1)
+        self.gen_cpu(increment_time=False)  # metric should not be dropped
+        self.gen_cpu(increment_time=False)  # metric should be dropped
+        self.gen_cpu(increment_time=False)  # metric should be dropped
+        assert_equals(len(self.collectd_engine.dispatched_values), 2)
 
     def test_memory_utilization(self):
         self.gen_memory()
@@ -112,6 +123,10 @@ class TestUtilizationFactory(object):
         assert_equals(len(self.collectd_engine.dispatched_values), 3)
         self.utilization_factory.read()
         assert_equals(len(self.collectd_engine.dispatched_values), 3)
+        self.gen_memory(increment_time=False)  # value should not be dropped
+        self.gen_memory(increment_time=False)  # value should be dropped
+        self.gen_memory(increment_time=False)  # value should be dropped
+        assert_equals(len(self.collectd_engine.dispatched_values), 4)
 
     def test_df_utilizaton(self):
         self.gen_df()
@@ -141,6 +156,12 @@ class TestUtilizationFactory(object):
         for v in self.collectd_engine.dispatched_values:
             assert_equals(v.values[0], 50.0)
 
+        self.gen_df(increment_time=False)  # metric should not be dropped
+        self.gen_df(increment_time=False)  # metric should be dropped
+        self.gen_df(increment_time=False)  # metric should be dropped
+
+        # assert_equals(len(self.collectd_engine.dispatched_values), 16)
+
         # test the addition of plugin_instances
         self.gen_df()
         assert_equals(len(self.collectd_engine.dispatched_values), 19)
@@ -164,6 +185,10 @@ class TestUtilizationFactory(object):
         last = self.collectd_engine.dispatched_values[4]
         # should be 4 more instead of 6
         assert_equals(prev.values[0] + 4, last.values[0])
+        self.gen_disk(increment_time=False)  # metric should be dropped
+        self.gen_disk(increment_time=False)  # metric should be dropped
+        self.gen_disk(increment_time=False)  # value should be dropped
+        assert_equals(len(self.collectd_engine.dispatched_values), 5)
 
     def test_network_total(self):
         self.gen_network()
@@ -182,6 +207,10 @@ class TestUtilizationFactory(object):
         last = self.collectd_engine.dispatched_values[4]
         # should be 4 more instead of 6
         assert_equals(prev.values[0] + 4, last.values[0])
+        self.gen_network(increment_time=False)  # metric should be dropped
+        self.gen_network(increment_time=False)  # metric should be dropped
+        self.gen_network(increment_time=False)  # metric should be dropped
+        assert_equals(len(self.collectd_engine.dispatched_values), 5)
 
 
 t = TestUtilizationFactory()


### PR DESCRIPTION
log outdated values rather than emitting them
bump signalfx-python to version 1.0.7
add scripts to issue travis tests locally in an ubuntu xenail container
