### PR TITLE
Added "distribution" type to class mapping dict

### DIFF
--- a/src/aggregator.py
+++ b/src/aggregator.py
@@ -918,6 +918,7 @@ class MetricsAggregator(Aggregator):
             'c': Counter,
             'h': Histogram,
             'ms': Histogram,
+            'd': Histogram,
             's': Set,
             '_dd-r': Rate,
         }


### PR DESCRIPTION
Added mapping to DD "distribution" type to "Histogram" based on https://docs.datadoghq.com/developers/metrics/ and https://docs.datadoghq.com/developers/metrics/distributions/. This has already been tested and confirmed working in the field.

This is to address the following observed problem: 
```
time="2018-10-25T12:18:29Z" level=info msg="ERROR:dogstatsd:Error receiving datagram" collectdInstance=global
time="2018-10-25T12:18:29Z" level=info msg="Traceback (most recent call last):
  File "/plugins/collectd/signalfx/src/dogstatsd.py", line 169, in _start
    aggregator_submit(message)
  File "/plugins/collectd/signalfx/src/aggregator.py", line 649, in submit_packets
    device_name=device_name, sample_rate=sample_rate)
  File "/plugins/collectd/signalfx/src/aggregator.py", line 823, in submit_metric
    metric_class = self.metric_type_to_class[mtype]" collectdInstance=global
time="2018-10-25T12:18:29Z" level=info msg="KeyError: u'd'" collectdInstance=global
```